### PR TITLE
fix: remove charset option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     // and enable '--allowSyntheticDefaultImports' for typesystem compatibility.
     // Convenient for import assert from 'assert'
     "esModuleInterop": true,
-    "charset": "utf8",
     // Allow javascript files to be compiled.
     // Egg compile to in place, will throw can not overwrite js file
     "allowJs": false,


### PR DESCRIPTION
Option 'charset' is deprecated and will stop functioning in TypeScript 5.5

closes https://github.com/eggjs/egg/issues/5173

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->