### PR TITLE
feat: esm only

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,10 +5,11 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  merge_group:
 
 jobs:
   Job:
     name: Node.js
     uses: node-modules/github-actions/.github/workflows/node-test.yml@master
     with:
-      version: '18, 20, 22'
+      version: '22, 24'

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "lint": "echo 'ignore'",
     "test": "node --test --test-force-exit --experimental-strip-types test/index.test.ts",
-    "ci": "c8 -r html -r lcov -r text npm test"
+    "ci": "npm test"
   },
   "author": "killagu <killa123@126.com>",
   "license": "MIT",
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@types/node": "24",
-    "c8": "10",
     "coffee": "5",
     "typescript": "5"
   },

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   ],
   "scripts": {
     "lint": "echo 'ignore'",
-    "test": "egg-bin test",
-    "ci": "egg-bin cov"
+    "test": "node --test --test-force-exit --experimental-strip-types test/index.test.ts",
+    "ci": "c8 -r html -r lcov -r text npm test"
   },
   "author": "killagu <killa123@126.com>",
   "license": "MIT",
@@ -26,13 +26,13 @@
     "url": "https://github.com/eggjs/tsconfig.git"
   },
   "engines": {
-    "node": ">=18.19.0"
+    "node": ">=22.17.1"
   },
   "devDependencies": {
-    "@eggjs/bin": "7",
-    "@types/mocha": "10",
-    "@types/node": "22",
+    "@types/node": "24",
+    "c8": "10",
     "coffee": "5",
     "typescript": "5"
-  }
+  },
+  "type": "module"
 }

--- a/test/fixtures/apps/ts-proj/Foo.ts
+++ b/test/fixtures/apps/ts-proj/Foo.ts
@@ -1,8 +1,4 @@
-function FooDecorator() {
-  return function (target: any) {
-    console.log('decorator to class: ', target);
-  }
-}
+import FooDecorator from './FooDecorator.ts';
 
 @FooDecorator()
 export class Foo {

--- a/test/fixtures/apps/ts-proj/FooDecorator.ts
+++ b/test/fixtures/apps/ts-proj/FooDecorator.ts
@@ -1,0 +1,6 @@
+export default function FooDecorator() {
+  return function (target: any) {
+    console.log('decorator to class: ', target);
+  }
+}
+

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,20 +1,22 @@
-import coffee from 'coffee';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import assert from 'node:assert/strict';
+import { test } from 'node:test';
 
-describe('test/index.test.ts', () => {
-  it('should work', async () => {
-    const tsc = require.resolve('typescript/bin/tsc');
-    const fixturePath = path.join(__dirname, 'fixtures/apps/ts-proj');
-    const tsconfigPath = path.join(fixturePath, 'tsconfig.json');
-    await coffee.fork(tsc, [ '-p', tsconfigPath ], {
-      cwd: fixturePath,
-    })
-      .debug()
-      .expect('code', 0)
-      .end();
+import coffee from 'coffee';
 
-    assert(await fs.stat(path.join(fixturePath, 'dist')));
-  });
+test('should tsc build work', async () => {
+  const tsc = path.join(import.meta.dirname, '..', 'node_modules', 'typescript', 'bin', 'tsc');
+  const fixturePath = path.join(import.meta.dirname, 'fixtures/apps/ts-proj');
+  const tsconfigPath = path.join(fixturePath, 'tsconfig.json');
+  console.log('%s -p %s, cwd: %s', tsc, tsconfigPath, fixturePath);
+
+  await coffee.fork(tsc, [ '-p', tsconfigPath ], {
+    cwd: fixturePath,
+  })
+    .debug()
+    .expect('code', 0)
+    .end();
+
+  assert(await fs.stat(path.join(fixturePath, 'dist')));
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "strict": true,
     "noImplicitAny": true,
-    "target": "ES2022",
+    // https://node.green/#ES2024
+    "target": "ES2024",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     // Emit '__importStar' and '__importDefault' helpers for runtime babel ecosystem compatibility
@@ -32,6 +33,10 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "useUnknownInCatchVariables": true,
-    "incremental": false
+    "incremental": false,
+    // https://nodejs.org/en/learn/typescript/publishing-a-ts-package#treat-types-like-a-test
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true,
+    "rewriteRelativeImportExtensions": true
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: drop Node.js < 22.17.1 support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Node.js version requirements and CI workflow to support Node.js 22 and 24.
  * Improved test scripts by switching to the native Node.js test runner and simplifying CI commands.
  * Updated development dependencies and set the package type to module.
  * Upgraded TypeScript configuration to target ES2024 and added new module-related compiler options.
  * Refactored test files to use the Node.js test module instead of Mocha.
  * Modularized a class decorator by moving it to an external file for better code organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->